### PR TITLE
Use Hash::FieldHash for inside out objects.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -12,6 +12,7 @@ my $build = Module::Build->new(
     requires => {
         'perl'              => 5.008,
         'Exporter::Declare' => '0.102',
+        'Hash::FieldHash'   => '0.09',
         'Scalar::Util'      => 0,
         'List::Util'        => 0,
         'Devel::Declare::Parser' => '0.017',

--- a/lib/Exodist/Util/Sub.pm
+++ b/lib/Exodist/Util/Sub.pm
@@ -6,12 +6,13 @@ use Exporter::Declare '-magic';
 use Exodist::Util::Package qw/inject_sub/;
 use Carp qw/croak/;
 use B;
+use Hash::FieldHash qw(fieldhash);
 
 default_exports qw/
     enhance_sub
 /;
 
-our %STASH;
+fieldhash my %STASH;
 
 default_export( 'enhanced_sub', 'sublike' );
 default_export( 'esub', 'sublike', \&enhanced_sub );
@@ -84,11 +85,6 @@ sub is_anon {
 sub original_package {
     my $self = shift;
     return B::svref_2object( $self )->GV->STASH->NAME;
-}
-
-sub DESTROY {
-    my $self = shift;
-    delete $STASH{ $self };
 }
 
 1;


### PR DESCRIPTION
This makes it safe for threads.

Hash::FieldHash performs better than Hash::Util::FieldHash.

A destructor to clear the field hash is no longer necessary, the
field hash takes care of that.

For #2
